### PR TITLE
Handle stream `end` event.

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -152,6 +152,10 @@ Collection.prototype.stream = function find(criteria, stream) {
   dbStream.on('close', function() {
     stream.end();
   });
+  // stream has ended
+  dbStream.on('end', function() {
+    stream.end();
+  });
 };
 
 /**


### PR DESCRIPTION
Stream was only ended upon connection close, and not on stream ending.
